### PR TITLE
Revert "temporarily disabled gnome-extensions"

### DIFF
--- a/playbook-ubuntu.yml
+++ b/playbook-ubuntu.yml
@@ -17,7 +17,7 @@
       - include: tasks/git.yml
       tags: git
     - include: tasks/gnome-packages.yml
-#    - include: tasks/gnome-extensions.yml
+    - include: tasks/gnome-extensions.yml
     - include: tasks/gnome-configurations.yml
     - include: tasks/gnome-tracker.yml
     - include: tasks/flatpak.yml


### PR DESCRIPTION
This reverts commit 0beb3caa99f17b6c4e85b70ef51b9887745bbc1d.

Closes #25 